### PR TITLE
Handle large memcached keys more gracefully

### DIFF
--- a/includes/memcached-adapter.php
+++ b/includes/memcached-adapter.php
@@ -120,7 +120,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function add( $key, $connection_group, $data, $expiration ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->add( $this->maybe_reduce_key_length( $key ), $data, $expiration );
+		return $mc->add( $this->normalize_key( $key ), $data, $expiration );
 	}
 
 	/**
@@ -135,7 +135,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function replace( $key, $connection_group, $data, $expiration ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->replace( $this->maybe_reduce_key_length( $key ), $data, $expiration );
+		return $mc->replace( $this->normalize_key( $key ), $data, $expiration );
 	}
 
 	/**
@@ -150,7 +150,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function set( $key, $connection_group, $data, $expiration ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->set( $this->maybe_reduce_key_length( $key ), $data, $expiration );
+		return $mc->set( $this->normalize_key( $key ), $data, $expiration );
 	}
 
 	/**
@@ -164,7 +164,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	public function get( $key, $connection_group ) {
 		$mc = $this->get_connection( $connection_group );
 		/** @psalm-suppress MixedAssignment */
-		$value = $mc->get( $this->maybe_reduce_key_length( $key ) );
+		$value = $mc->get( $this->normalize_key( $key ) );
 
 		return [
 			'value' => $value,
@@ -183,7 +183,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function get_multiple( $keys, $connection_group ) {
 		$mc          = $this->get_connection( $connection_group );
-		$mapped_keys = $this->maybe_reduce_key_lengths_with_mapping( $keys );
+		$mapped_keys = $this->normalize_keys_with_mapping( $keys );
 
 		/** @psalm-var array<string, mixed>|false $results */
 		$results = $mc->getMulti( array_keys( $mapped_keys ) );
@@ -211,7 +211,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function delete( $key, $connection_group ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->delete( $this->maybe_reduce_key_length( $key ) );
+		return $mc->delete( $this->normalize_key( $key ) );
 	}
 
 	/**
@@ -224,7 +224,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function delete_multiple( $keys, $connection_group ) {
 		$mc          = $this->get_connection( $connection_group );
-		$mapped_keys = $this->maybe_reduce_key_lengths_with_mapping( $keys );
+		$mapped_keys = $this->normalize_keys_with_mapping( $keys );
 
 		/** @psalm-var array<string, true|int> $results */
 		$results = $mc->deleteMulti( array_keys( $mapped_keys ) );
@@ -251,7 +251,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function increment( $key, $connection_group, $offset ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->increment( $this->maybe_reduce_key_length( $key ), $offset );
+		return $mc->increment( $this->normalize_key( $key ), $offset );
 	}
 
 	/**
@@ -265,7 +265,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function decrement( $key, $connection_group, $offset ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->decrement( $this->maybe_reduce_key_length( $key ), $offset );
+		return $mc->decrement( $this->normalize_key( $key ), $offset );
 	}
 
 	/**
@@ -446,7 +446,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 * @param string $key
 	 * @psalm-return string
 	 */
-	private function maybe_reduce_key_length( $key ) {
+	private function normalize_key( $key ) {
 		if ( strlen( $key ) <= 250 ) {
 			return $key;
 		} else {
@@ -460,11 +460,11 @@ class Memcached_Adapter implements Adapter_Interface {
 	 * @param string[] $keys
 	 * @psalm-return array<string, string>
 	 */
-	private function maybe_reduce_key_lengths_with_mapping( $keys ) {
+	private function normalize_keys_with_mapping( $keys ) {
 		$mapped_keys = [];
 
 		foreach ( $keys as $key ) {
-			$mapped_keys[ $this->maybe_reduce_key_length( $key ) ] = $key;
+			$mapped_keys[ $this->normalize_key( $key ) ] = $key;
 		}
 
 		return $mapped_keys;

--- a/includes/memcached-adapter.php
+++ b/includes/memcached-adapter.php
@@ -120,7 +120,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function add( $key, $connection_group, $data, $expiration ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->add( $key, $data, $expiration );
+		return $mc->add( $this->maybe_reduce_key_length( $key ), $data, $expiration );
 	}
 
 	/**
@@ -135,7 +135,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function replace( $key, $connection_group, $data, $expiration ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->replace( $key, $data, $expiration );
+		return $mc->replace( $this->maybe_reduce_key_length( $key ), $data, $expiration );
 	}
 
 	/**
@@ -150,7 +150,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function set( $key, $connection_group, $data, $expiration ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->set( $key, $data, $expiration );
+		return $mc->set( $this->maybe_reduce_key_length( $key ), $data, $expiration );
 	}
 
 	/**
@@ -164,7 +164,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	public function get( $key, $connection_group ) {
 		$mc = $this->get_connection( $connection_group );
 		/** @psalm-suppress MixedAssignment */
-		$value = $mc->get( $key );
+		$value = $mc->get( $this->maybe_reduce_key_length( $key ) );
 
 		return [
 			'value' => $value,
@@ -179,13 +179,26 @@ class Memcached_Adapter implements Adapter_Interface {
 	 * @param string $connection_group The group, used to find the right connection pool.
 	 *
 	 * @return array<mixed>|false Will not return anything in the array for unfound keys.
+	 * @psalm-suppress MixedAssignment
 	 */
 	public function get_multiple( $keys, $connection_group ) {
-		$mc = $this->get_connection( $connection_group );
-		/** @psalm-suppress MixedAssignment */
-		$result = $mc->getMulti( $keys );
+		$mc          = $this->get_connection( $connection_group );
+		$mapped_keys = $this->maybe_reduce_key_lengths_with_mapping( $keys );
 
-		return is_array( $result ) ? $result : false;
+		/** @psalm-var array<string, mixed>|false $results */
+		$results = $mc->getMulti( array_keys( $mapped_keys ) );
+
+		if ( ! is_array( $results ) ) {
+			return false;
+		}
+
+		$return = [];
+		foreach ( $results as $result_key => $result_value ) {
+			$original_key            = isset( $mapped_keys[ $result_key ] ) ? $mapped_keys[ $result_key ] : $result_key;
+			$return[ $original_key ] = $result_value;
+		}
+
+		return $return;
 	}
 
 	/**
@@ -198,7 +211,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function delete( $key, $connection_group ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->delete( $key );
+		return $mc->delete( $this->maybe_reduce_key_length( $key ) );
 	}
 
 	/**
@@ -210,14 +223,18 @@ class Memcached_Adapter implements Adapter_Interface {
 	 * @return array<string, boolean>
 	 */
 	public function delete_multiple( $keys, $connection_group ) {
-		$mc      = $this->get_connection( $connection_group );
-		$results = $mc->deleteMulti( $keys );
+		$mc          = $this->get_connection( $connection_group );
+		$mapped_keys = $this->maybe_reduce_key_lengths_with_mapping( $keys );
+
+		/** @psalm-var array<string, true|int> $results */
+		$results = $mc->deleteMulti( array_keys( $mapped_keys ) );
 
 		$return = [];
-		/** @psalm-suppress MixedAssignment */
-		foreach ( $results as $key => $result ) {
+		foreach ( $results as $result_key => $result_value ) {
+			$original_key = isset( $mapped_keys[ $result_key ] ) ? $mapped_keys[ $result_key ] : $result_key;
+
 			// deleteMulti() returns true on success, but one of the Memcached::RES_* constants if failed.
-			$return[ (string) $key ] = true === $result;
+			$return[ $original_key ] = true === $result_value;
 		}
 
 		return $return;
@@ -234,7 +251,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function increment( $key, $connection_group, $offset ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->increment( $key, $offset );
+		return $mc->increment( $this->maybe_reduce_key_length( $key ), $offset );
 	}
 
 	/**
@@ -248,7 +265,7 @@ class Memcached_Adapter implements Adapter_Interface {
 	 */
 	public function decrement( $key, $connection_group, $offset ) {
 		$mc = $this->get_connection( $connection_group );
-		return $mc->decrement( $key, $offset );
+		return $mc->decrement( $this->maybe_reduce_key_length( $key ), $offset );
 	}
 
 	/**
@@ -417,5 +434,39 @@ class Memcached_Adapter implements Adapter_Interface {
 		}
 
 		return $server_keys;
+	}
+
+	/**
+	 * Memcached can only handle keys with a length of 250 or less.
+	 * The Memcache extension automatically truncates. Memcached does not.
+	 * Instead of truncation, which can lead to some hidden consequences,
+	 * we can hash the string and use a shortened version when interacting
+	 * with the Memcached servers.
+	 *
+	 * @param string $key
+	 * @psalm-return string
+	 */
+	private function maybe_reduce_key_length( $key ) {
+		if ( strlen( $key ) <= 250 ) {
+			return $key;
+		} else {
+			return substr( $key, 0, 200 ) . ':truncated:' . md5( $key );
+		}
+	}
+
+	/**
+	 * Reduce key lenths while providing a map of new_key => original_key.
+	 *
+	 * @param string[] $keys
+	 * @psalm-return array<string, string>
+	 */
+	private function maybe_reduce_key_lengths_with_mapping( $keys ) {
+		$mapped_keys = [];
+
+		foreach ( $keys as $key ) {
+			$mapped_keys[ $this->maybe_reduce_key_length( $key ) ] = $key;
+		}
+
+		return $mapped_keys;
 	}
 }

--- a/tests/test-wp-object-cache.php
+++ b/tests/test-wp-object-cache.php
@@ -791,10 +791,10 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 			self::assertTrue( $this->object_cache->delete( $key ) );
 		}
 
-		self::assertEquals( $this->object_cache->add_multiple( $large_keys ), array_map( fn() => true, $large_keys ) );
-		self::assertEquals( $this->object_cache->delete_multiple( array_keys( $large_keys ) ), array_map( fn() => true, $large_keys ) );
-		self::assertEquals( $this->object_cache->set_multiple( $large_keys ), $large_keys );
-		self::assertEquals( $this->object_cache->get_multiple( array_keys( $large_keys ) ), $large_keys );
+		self::assertSame( $this->object_cache->add_multiple( $large_keys ), array_map( fn() => true, $large_keys ) );
+		self::assertSame( $this->object_cache->delete_multiple( array_keys( $large_keys ) ), array_map( fn() => true, $large_keys ) );
+		self::assertSame( $this->object_cache->set_multiple( $large_keys ), array_map( fn() => true, $large_keys ) );
+		self::assertSame( $this->object_cache->get_multiple( array_keys( $large_keys ) ), $large_keys );
 	}
 
 	/*

--- a/tests/test-wp-object-cache.php
+++ b/tests/test-wp-object-cache.php
@@ -770,6 +770,35 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 	/*
 	|--------------------------------------------------------------------------
+	| Various edge cases.
+	|--------------------------------------------------------------------------
+	*/
+
+	public function test_large_key_lengths() {
+		$large_keys = [
+			str_repeat( 'a', 100 )  => 'a value',
+			str_repeat( 'b', 250 )  => 'b value',
+			str_repeat( 'c', 1000 ) => 'c value',
+		];
+
+		foreach ( $large_keys as $key => $_value ) {
+			self::assertTrue( $this->object_cache->add( $key, 1 ) );
+			self::assertTrue( $this->object_cache->replace( $key, 2 ) );
+			self::assertTrue( $this->object_cache->set( $key, 3 ) );
+			self::assertEquals( $this->object_cache->incr( $key ), 4 );
+			self::assertEquals( $this->object_cache->decr( $key, 3 ), 1 );
+			self::assertEquals( $this->object_cache->get( $key ), 1 );
+			self::assertTrue( $this->object_cache->delete( $key ) );
+		}
+
+		self::assertEquals( $this->object_cache->add_multiple( $large_keys ), array_map( fn() => true, $large_keys ) );
+		self::assertEquals( $this->object_cache->delete_multiple( array_keys( $large_keys ) ), array_map( fn() => true, $large_keys ) );
+		self::assertEquals( $this->object_cache->set_multiple( $large_keys ), $large_keys );
+		self::assertEquals( $this->object_cache->get_multiple( array_keys( $large_keys ) ), $large_keys );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
 	| Internal methods, mostly deals with flush numbers, the pseudo-cache-flushing mechanic.
 	|--------------------------------------------------------------------------
 	*/


### PR DESCRIPTION
The `Memcache` php extension automatically truncates keys over 250 length. This isn't super ideal, since the part being truncated could have been the bit that varied between keys. As in: `{$some_large_key_string} + {$post_id}`.

The Memcached php extension doesn't truncate and will just fail any operation instead. I like this approach more, but for compatibility we need to do something as there are plugins using unbounded strings such as parts of a page url as apart of the key - so they do extend past the 250 limit Memcached server limit.

Rather than implementing app-side truncation, this approach instead will hash the string when it's over the limit and append it to the first 200 chars before sending to the servers. This happens very late in the process, so no user-land bits are affected or will even know about this happening. The benefit for keeping the first 200 chars is just in case some exploration is being done trying to debug issues starting at the server side. It should be more than enough to track down the source of the key creations. I've added a `:truncated:` string as well to help signify when this behavior has taken place. A sort of clue for any future debuggers.