### PR TITLE
Add `AllowDynamicProperties` attribute to the `WP_Object_Cache` class

### DIFF
--- a/includes/wp-object-cache.php
+++ b/includes/wp-object-cache.php
@@ -6,7 +6,7 @@ use Automattic\Memcached\Memcache_Adapter;
 use Automattic\Memcached\Stats;
 
 // Note that this class is in the global namespace for backwards-compatibility reasons.
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class WP_Object_Cache {
 	public string $flush_group        = 'WP_Object_Cache';
 	public string $global_flush_group = 'WP_Object_Cache_global';

--- a/includes/wp-object-cache.php
+++ b/includes/wp-object-cache.php
@@ -6,6 +6,7 @@ use Automattic\Memcached\Memcache_Adapter;
 use Automattic\Memcached\Stats;
 
 // Note that this class is in the global namespace for backwards-compatibility reasons.
+#[AllowDynamicProperties]
 class WP_Object_Cache {
 	public string $flush_group        = 'WP_Object_Cache';
 	public string $global_flush_group = 'WP_Object_Cache_global';


### PR DESCRIPTION
## Description

```
 Creation of dynamic property WP_Object_Cache::$memcache_debug is deprecated
```

I found this while testing a client site on PHP 8.2 using [this project](https://github.com/alleyinteractive/mantle-framework/blob/4961ae56da6464d0b4732f075ea8e9ca2b3e2d89/src/mantle/testing/concerns/trait-wordpress-state.php#L38C21-L38C35).
