### PR TITLE
Allow non-persistent groups to have data add()ed after a failed get()

### DIFF
--- a/includes/wp-object-cache.php
+++ b/includes/wp-object-cache.php
@@ -139,13 +139,13 @@ class WP_Object_Cache {
 		}
 
 		if ( $this->is_non_persistent_group( $group ) ) {
-			if ( isset( $this->cache[ $key ] ) ) {
+			if ( ! empty( $this->cache[ $key ][ 'found' ] ) ) {
 				return false;
 			}
 
 			$this->cache[ $key ] = [
 				'value' => $data,
-				'found' => false,
+				'found' => true,
 			];
 
 			return true;

--- a/tests/test-wp-object-cache.php
+++ b/tests/test-wp-object-cache.php
@@ -853,6 +853,41 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		$this->assertStringContainsString( $this->object_cache->blog_prefix, $this->object_cache->key( 'foo', 'non-global-group' ) );
 	}
 
+	public function test_non_persistent_themes_group() {
+		$key = 'theme-test-key';
+		$group = 'themes';
+		$data = [
+			'block_theme' => true,
+			'block_template_folders' => [
+				'wp_template' => 'templates',
+				'wp_template_part' => 'parts'
+			],
+			'headers' => [
+				'Name' => 'Test Theme',
+			],
+			'stylesheet' => 'test-theme',
+			'template' => 'test-theme'
+		];
+		$expiration = 300;
+
+		$this->object_cache->add_non_persistent_groups( 'themes' );
+
+		// Ensure 'themes' is in non-persistent groups
+		$this->assertContains( $group, $this->object_cache->no_mc_groups, "'themes' should be in non-persistent groups" );
+
+		// Step 1: Attempt to get the data before adding
+		$pre_get_result = $this->object_cache->get( $key, $group );
+		$this->assertFalse( $pre_get_result, 'Data should not be present before adding to non-persistent group' );
+
+		// Step 2: Attempt to add the data to cache
+		$add_result = $this->object_cache->add( $key, $data, $group, $expiration );
+		$this->assertTrue( $add_result, 'Adding data to non-persistent group should succeed' );
+
+		// Step 3: Attempt to get the data immediately after adding
+		$get_result = $this->object_cache->get( $key, $group );
+		$this->assertEquals( $data, $get_result, 'Data should be retrieved immediately after adding to non-persistent group' );
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Testing Utils


### PR DESCRIPTION
This is to fix the bug as described in here: p55Cj4-3nK-p2

However, this change causes many other failures, because several tests are expecting "found" to be false even after setting data. Example: https://github.com/Automattic/wp-cache-memcached/blob/a104fc5c3bfeea2e35409a21627a1778b372fd16/tests/test-wp-object-cache.php#L164

I don't quite understand why this is. Any thoughts here?

```
24) Test_WP_Object_Cache::test_replace_for_non_persistent_groups with data set "string" ('string', '')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'value' => ''
-    'found' => true
+    'found' => false
 )
                                                                                                                            
/home/circleci/project/tests/test-wp-object-cache.php:163
                                                                                                                            
25) Test_WP_Object_Cache::test_replace_for_non_persistent_groups with data set "float" (1.234, 5.678)
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'value' => 5.678
-    'found' => true
+    'found' => false
 )
                                                                                                                            
/home/circleci/project/tests/test-wp-object-cache.php:163
                                                                                                                            
26) Test_WP_Object_Cache::test_replace_for_non_persistent_groups with data set "object" (stdClass Object (...), stdClass Object ())
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'value' => stdClass Object ()
-    'found' => true
+    'found' => false
 )
                                                                                                                            
/home/circleci/project/tests/test-wp-object-cache.php:163
                                                                                                                            
FAILURES!
Tests: 151, Assertions: 786, Failures: 26.
```