### PR TITLE
Add .gitattributes file with export ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+bin export-ignore
+stubs export-ignore
+tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+composer.lock export-ignore
+phpcs.xml.dist export-ignore
+phpunit.xml.dist export-ignore
+psalm.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,25 @@
-bin export-ignore
-stubs export-ignore
-tests export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-composer.lock export-ignore
-phpcs.xml.dist export-ignore
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop this package using Composer, use `--prefer-source`.
+# https://blog.madewithlove.be/post/gitattributes/
+
+bin              export-ignore
+stubs            export-ignore
+tests            export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+composer.lock    export-ignore
+phpcs.xml.dist   export-ignore
 phpunit.xml.dist export-ignore
-psalm.xml.dist export-ignore
+psalm.xml.dist   export-ignore
+
+# Auto detect text files and perform LF normalization
+# https://pablorsk.medium.com/be-a-git-ninja-the-gitattributes-file-e58c07c9e915
+
+* text=auto
+
+# The above will handle all files NOT found below
+
+*.md  text
+*.php text
+*.inc text


### PR DESCRIPTION
When you use `git archive` all the test and stub files are also exported. The archive should usually only contain the production files since this is also the package installed by Composer by default, see https://getcomposer.org/doc/05-repositories.md#package.


**Testing instructions:**

1. Checkout the PR
2. `git archive -o latest.zip HEAD`
3. `unzip latest.zip`
4. `cd unzip`
5. `tree .` 

Expected output:

```
❯ tree .
.
├── composer.json
├── includes
│   ├── adapter-interface.php
│   ├── memcache-adapter.php
│   ├── memcached-adapter.php
│   ├── stats.php
│   └── wp-object-cache.php
├── object-cache.php
└── readme.md

2 directories, 8 files
```