### PR TITLE
Prevent TypeError when $table_prefix is unset during setup

### DIFF
--- a/includes/wp-object-cache.php
+++ b/includes/wp-object-cache.php
@@ -85,7 +85,7 @@ class WP_Object_Cache {
 
 		$is_ms = function_exists( 'is_multisite' ) && is_multisite();
 
-		$this->global_prefix = $is_ms || ( defined( 'CUSTOM_USER_TABLE' ) && defined( 'CUSTOM_USER_META_TABLE' ) ) ? '' : $table_prefix;
+		$this->global_prefix = $is_ms || ( defined('CUSTOM_USER_TABLE') && defined('CUSTOM_USER_META_TABLE') ) ? '' : (string) ($table_prefix ?? '');
 		$this->blog_prefix   = (string) ( $is_ms ? $blog_id : $table_prefix );
 
 		$use_memcached = defined( 'AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION' ) && AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION;

--- a/includes/wp-object-cache.php
+++ b/includes/wp-object-cache.php
@@ -85,7 +85,7 @@ class WP_Object_Cache {
 
 		$is_ms = function_exists( 'is_multisite' ) && is_multisite();
 
-		$this->global_prefix = $is_ms || ( defined('CUSTOM_USER_TABLE') && defined('CUSTOM_USER_META_TABLE') ) ? '' : (string) ($table_prefix ?? '');
+		$this->global_prefix = $is_ms || ( defined( 'CUSTOM_USER_TABLE' ) && defined( 'CUSTOM_USER_META_TABLE' ) ) ? '' : (string) ( $table_prefix ?? '' );
 		$this->blog_prefix   = (string) ( $is_ms ? $blog_id : $table_prefix );
 
 		$use_memcached = defined( 'AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION' ) && AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION;

--- a/includes/wp-object-cache.php
+++ b/includes/wp-object-cache.php
@@ -85,7 +85,7 @@ class WP_Object_Cache {
 
 		$is_ms = function_exists( 'is_multisite' ) && is_multisite();
 
-		$this->global_prefix = $is_ms || ( defined( 'CUSTOM_USER_TABLE' ) && defined( 'CUSTOM_USER_META_TABLE' ) ) ? '' : (string) ( $table_prefix ?? '' );
+		$this->global_prefix = $is_ms || ( defined( 'CUSTOM_USER_TABLE' ) && defined( 'CUSTOM_USER_META_TABLE' ) ) ? '' : (string) $table_prefix;
 		$this->blog_prefix   = (string) ( $is_ms ? $blog_id : $table_prefix );
 
 		$use_memcached = defined( 'AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION' ) && AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION;


### PR DESCRIPTION
Fixes a fatal error that occurs when the object cache initializes before $table_prefix is defined. I am using PHP 8.3 and WordPress 6.8.2 version.

**Original error message:**
```
2025/08/26 23:32:23 [error] 303000#0: *1188510 FastCGI sent in stderr: ＂PHP message: PHP Fatal error:  Uncaught TypeError: Cannot assign null to property WP_Object_Cache::$global_prefix of type string in /www/wwwroot/mywebsite.com/wp-content/mu-plugins/wp-cache-memcached/includes/wp-object-cache.php:88
Stack trace:
#0 /www/wwwroot/mywebsite.com/wp-content/mu-plugins/wp-cache-memcached/object-cache.php(32): WP_Object_Cache-＞__construct()
#1 /www/wwwroot/mywebsite.com/wp-includes/load.php(893): wp_cache_init()
#2 /www/wwwroot/mywebsite.com/wp-settings.php(147): wp_start_object_cache()
#3 /www/wwwroot/mywebsite.com/wp-admin/setup-config.php(33): require(＇...＇)
#4 {main}
  thrown in /www/wwwroot/mywebsite.com/wp-content/mu-plugins/wp-cache-memcached/includes/wp-object-cache.php on line 88＂ while reading response header from upstream, client: 172.70.47.82, server: mywebsite.com, request: ＂GET /wp-admin/setup-config.php HTTP/1.1＂, upstream: ＂fastcgi://unix:/tmp/php-cgi-83.sock:＂, host: ＂mywebsite.com＂
```