### PR TITLE
Fix: Preserve key salt when using Memcache_Adapter

### DIFF
--- a/includes/wp-object-cache.php
+++ b/includes/wp-object-cache.php
@@ -1019,7 +1019,7 @@ class WP_Object_Cache {
 	 */
 	public function salt_keys( $key_salt, $add_mc_prefix = false ) {
 		$key_salt = is_string( $key_salt ) && strlen( $key_salt ) ? $key_salt : '';
-		$key_salt = $add_mc_prefix ? $key_salt . '_mc' : '';
+		$key_salt = $add_mc_prefix ? $key_salt . '_mc' : $key_salt;
 
 		$this->key_salt = empty( $key_salt ) ? '' : $key_salt . ':';
 	}

--- a/tests/test-wp-object-cache.php
+++ b/tests/test-wp-object-cache.php
@@ -1023,6 +1023,20 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		$this->assertFalse( $this->object_cache->replace( 'delete_me', 'after_delete_value', $group ) );
 	}
 
+	public function test_salt_keys() {
+		// Empty key salt
+		$this->object_cache->salt_keys( '', false );
+		self::assertEquals( '', $this->object_cache->key_salt );
+
+		// Key salt, no prefix
+		$this->object_cache->salt_keys( 'mysite', false );
+		self::assertEquals( 'mysite:', $this->object_cache->key_salt );
+
+		// Key salt and mc prefix
+		$this->object_cache->salt_keys( 'mysite', true );
+		self::assertEquals( 'mysite_mc:', $this->object_cache->key_salt );
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Testing Utils


### PR DESCRIPTION
Fixes a bug in the `salt_keys()` method where the key salt was incorrectly discarded when `$add_mc_prefix` was false.

**Before:**
```php
$key_salt = $add_mc_prefix ? $key_salt . '_mc' : '';
```

**After:**
```php
$key_salt = $add_mc_prefix ? $key_salt . '_mc' : $key_salt;
```
---

If we look at the functions as they exist before this PR:

We call into `->salt_keys()` with the second argument, `$use_memcached=true` if we're using the "D" adapter. In this case, the function sets the salt to `WP_CACHE_KEY_SALT . "_mc"`. 
However, if we call it with `$use_memcached=false` when we're using the "Non-D" adapter, the function sets the salt to `''`. I think this is a bug and it was intending to set to `WP_CACHE_KEY_SALT`.

```php
	public function __construct( $adapter = null ) {
...
		$use_memcached = defined( 'AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION' ) && AUTOMATTIC_MEMCACHED_USE_MEMCACHED_EXTENSION;
		if ( ! is_null( $adapter ) ) {
			$this->adapter = $adapter;
		} else {
			$servers       = is_array( $memcached_servers ) ? $memcached_servers : [ 'default' => [ '127.0.0.1:11211' ] ];
			$this->adapter = $use_memcached ? new Memcached_Adapter( $servers ) : new Memcache_Adapter( $servers );
		}

		$this->salt_keys( WP_CACHE_KEY_SALT, $use_memcached );
...
}
```

salt_keys adds `"_mc"` to the $key_salt when $add_mc_prefix is true. But when it's false, the key salt is always ''. The value of the first argument is ignored.
```php
	public function salt_keys( $key_salt, $add_mc_prefix = false ) {
		$key_salt = is_string( $key_salt ) && strlen( $key_salt ) ? $key_salt : '';
		$key_salt = $add_mc_prefix ? $key_salt . '_mc' : '';  // <-- Note this wipes out the $key_salt in the "don't add" case 

		$this->key_salt = empty( $key_salt ) ? '' : $key_salt . ':';
	}
```

Also check the new test I added. Without this fix, this test will fail because the `->key_salt` is set to `''`.
```
		// Key salt, no prefix
		$this->object_cache->salt_keys( 'mysite', false );
		self::assertEquals( 'mysite:', $this->object_cache->key_salt );
```

